### PR TITLE
Incorporate magic arrows in rando settings

### DIFF
--- a/soh/soh/Enhancements/randomizer/3drando/settings.cpp
+++ b/soh/soh/Enhancements/randomizer/3drando/settings.cpp
@@ -304,8 +304,8 @@ namespace Settings {
   Option IngameSpoilers      = Option::Bool("Ingame Spoilers",        {"Hide", "Show"},                                                       {ingameSpoilersHideDesc, ingameSpoilersShowDesc });
   Option MenuOpeningButton   = Option::U8  ("Open Info Menu with",    {"Select","Start","D-Pad Up","D-Pad Down","D-Pad Right","D-Pad Left",}, {menuButtonDesc});
   Option RandomTrapDmg       = Option::U8  ("Random Trap Damage",     {"Off", "Basic", "Advanced"},                                           {randomTrapDmgDesc, basicTrapDmgDesc, advancedTrapDmgDesc},                                                       OptionCategory::Setting,    1); // Basic
-  Option BlueFireArrows      = Option::Bool("Blue Fire Arrows",       {"No", "Yes"},                                                          {blueFireArrowsDesc});
-  Option SunlightArrows      = Option::Bool("Sunlight Arrows",        {"No", "Yes"},                                                          {sunlightArrowsDesc});
+  Option BlueFireArrows      = Option::Bool("Blue Fire Arrows",       {"Off", "On"},                                                          {blueFireArrowsDesc});
+  Option SunlightArrows      = Option::Bool("Sunlight Arrows",        {"Off", "On"},                                                          {sunlightArrowsDesc});
   bool HasNightStart         = false;
   std::vector<Option *> miscOptions = {
     &GossipStoneHints,

--- a/soh/soh/Enhancements/randomizer/randomizer.cpp
+++ b/soh/soh/Enhancements/randomizer/randomizer.cpp
@@ -4348,7 +4348,7 @@ void DrawRandoEditor(bool& open) {
 
                 UIWidgets::PaddedSeparator();
 
-                UIWidgets::EnhancementCheckbox("WIP - Blue Fire Arrows", "gRandomizeBlueIceArrows", true, "In development");
+                UIWidgets::EnhancementCheckbox("Blue Fire Arrows", "gRandomizeBlueFireArrows");
                 UIWidgets::InsertHelpHoverText(
                     "Ice Arrows act like Blue Fire, making them able to melt red ice. "
                     "Item placement logic will respect this option, so it might be required to use this to progress."
@@ -4356,7 +4356,7 @@ void DrawRandoEditor(bool& open) {
 
                 UIWidgets::PaddedSeparator();
 
-                UIWidgets::EnhancementCheckbox("WIP - Sunlight Arrows", "gRandomizeSunlightArrows", true, "In development");
+                UIWidgets::EnhancementCheckbox("Sunlight Arrows", "gRandomizeSunlightArrows");
                 UIWidgets::InsertHelpHoverText(
                     "Light Arrows can be used to light up the sun switches instead of using the Mirror Shield. "
                     "Item placement logic will respect this option, so it might be required to use this to progress."

--- a/soh/soh/GameMenuBar.cpp
+++ b/soh/soh/GameMenuBar.cpp
@@ -888,10 +888,25 @@ namespace GameMenuBar {
                 UIWidgets::Tooltip("Injects Golden Skulltula total count in pickup messages");
                 UIWidgets::PaddedEnhancementCheckbox("Pull grave during the day", "gDayGravePull", true, false);
                 UIWidgets::Tooltip("Allows graves to be pulled when child during the day");
-                UIWidgets::PaddedEnhancementCheckbox("Blue Fire Arrows", "gBlueFireArrows", true, false);
-                UIWidgets::Tooltip("Allows Ice Arrows to melt red ice");
-                UIWidgets::PaddedEnhancementCheckbox("Sunlight Arrows", "gSunlightArrows", true, false);
-                UIWidgets::Tooltip("Allows Light Arrows to activate sun switches");
+
+                // Blue Fire Arrows
+                bool forceEnableBlueFireArrows = gSaveContext.n64ddFlag &&
+                    OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_BLUE_FIRE_ARROWS);
+                const char* forceEnableBlueFireArrowsText =
+                    "This setting is forcefully enabled because a savefile\nwith \"Blue Fire Arrows\" is loaded.";
+                UIWidgets::PaddedEnhancementCheckbox("Blue Fire Arrows", "gBlueFireArrows", true, false, 
+                    forceEnableBlueFireArrows, forceEnableBlueFireArrowsText, UIWidgets::CheckboxGraphics::Checkmark);
+                UIWidgets::Tooltip("Allows Ice Arrows to melt red ice.");
+
+                // Sunlight Arrows
+                bool forceEnableSunLightArrows = gSaveContext.n64ddFlag &&
+                    OTRGlobals::Instance->gRandomizer->GetRandoSettingValue(RSK_SUNLIGHT_ARROWS);
+                const char* forceEnableSunLightArrowsText =
+                    "This setting is forcefully enabled because a savefile\nwith \"Sunlight Arrows\" is loaded.";
+                UIWidgets::PaddedEnhancementCheckbox("Sunlight Arrows", "gSunlightArrows", true, false, 
+                    forceEnableSunLightArrows, forceEnableSunLightArrowsText, UIWidgets::CheckboxGraphics::Checkmark);
+                UIWidgets::Tooltip("Allows Light Arrows to activate sun switches.");
+
                 ImGui::EndMenu();
             }
 

--- a/soh/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/soh/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -105,7 +105,7 @@ void BgBreakwall_Init(Actor* thisx, GlobalContext* globalCtx) {
     s32 pad;
     s32 wallType = ((this->dyna.actor.params >> 13) & 3) & 0xFF;
 
-    blueFireArrowsDC = (CVar_GetS32("gBlueFireArrows", 0) != 0);
+    blueFireArrowsDC = CVar_GetS32("gBlueFireArrows", 0) || (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_BLUE_FIRE_ARROWS));
 
     Actor_ProcessInitChain(&this->dyna.actor, sInitChain);
     DynaPolyActor_Init(&this->dyna, DPM_UNK);

--- a/soh/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
+++ b/soh/src/overlays/actors/ovl_Bg_Ice_Shelter/z_bg_ice_shelter.c
@@ -103,7 +103,7 @@ void func_80890740(BgIceShelter* this, GlobalContext* globalCtx) {
     s32 pad;
     s32 type = (this->dyna.actor.params >> 8) & 7;
 
-    blueFireArrows = (CVar_GetS32("gBlueFireArrows", 0) != 0);
+    blueFireArrows = CVar_GetS32("gBlueFireArrows", 0) || (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_BLUE_FIRE_ARROWS));
 
     Collider_InitCylinder(globalCtx, &this->cylinder1);
     // If "Blue Fire Arrows" is enabled, set up a collider on the red ice that responds to them

--- a/soh/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
+++ b/soh/src/overlays/actors/ovl_Bg_Jya_Lift/z_bg_jya_lift.c
@@ -98,7 +98,8 @@ void BgJyaLift_DelayMove(BgJyaLift* this, GlobalContext* globalCtx) {
         if (this->moveDelay >= 20) {
             // Skip this cutscene if using Sunlight Arrows in rando, since activating the switch while
             // not standing on the platform will cause the cutscene to show the unloaded central room
-            if (!(gSaveContext.n64ddFlag && CVar_GetS32("gSunlightArrows", 0) != 0)) {
+            if (!(gSaveContext.n64ddFlag &&
+                  (CVar_GetS32("gSunlightArrows", 0) || Randomizer_GetSettingValue(RSK_SUNLIGHT_ARROWS)))) {
                 OnePointCutscene_Init(globalCtx, 3430, -99, &this->dyna.actor, MAIN_CAM);
             }
             BgJyaLift_SetupMove(this);

--- a/soh/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
+++ b/soh/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
@@ -121,7 +121,7 @@ static InitChainEntry sInitChain[] = {
 
 void ObjLightswitch_InitCollider(ObjLightswitch* this, GlobalContext* globalCtx) {
     s32 pad;
-    sunLightArrows = (CVar_GetS32("gSunlightArrows", 0) != 0);
+    sunLightArrows = CVar_GetS32("gSunlightArrows", 0) || (gSaveContext.n64ddFlag && Randomizer_GetSettingValue(RSK_SUNLIGHT_ARROWS));
 
     Collider_InitJntSph(globalCtx, &this->collider);
     // If "Sunlight Arrows" is enabled, set up the collider to allow Light Arrow hits


### PR DESCRIPTION
Feel free to test them it out yourself. I've made a rando save with both enabled in the settings with the CVar off, and red ice, dodongo walls and sun thingies work fine. Then I did one without the rando settings and toggling the default enhancements work as intended. 